### PR TITLE
Use axios instead of fetch.

### DIFF
--- a/api/fetch.ts
+++ b/api/fetch.ts
@@ -1,0 +1,7 @@
+import { AxiosRequestConfig } from "axios";
+
+export let globalConfig: Partial<AxiosRequestConfig> = {};
+
+export function setGlobalConfig(config: Partial<AxiosRequestConfig>) {
+    globalConfig = config;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,14 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -177,6 +185,11 @@
           "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
         }
       }
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "blakejs": "^1.2.1",
     "json-schema-to-typescript": "^10.1.5",
-    "tweetnacl": "^1.0.3"
+    "tweetnacl": "^1.0.3",
+    "axios": "^0.21.4"
   }
 }


### PR DESCRIPTION
This allows the app code to use native HTTP clients, which is beneficial in several ways. Most importantly, it allows the app to ignore same-origin policy, which removes the need for CORS and allows for APIs to be "desktop app only", occasionally a useful distinction in situations where the browser and its session can be considered less trustworthy.