### PR TITLE
add subscriptionId to json schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -192,7 +192,8 @@
         "passwordSet",
         "canUnsetPassword",
         "unsubscribedFromEmails",
-        "customerId"
+        "customerId",
+        "subscriptionId"
       ],
       "properties": {
         "sessionAge": {
@@ -263,6 +264,9 @@
           "type": "boolean"
         },
         "customerId": {
+          "type": "string"
+        },
+        "subscriptionId": {
           "type": "string"
         }
       },


### PR DESCRIPTION
Adds missing `subscriptionId` to the schema - will solve tsc / lint errors on the redesign branch on the website